### PR TITLE
Add support for 32-bit platforms

### DIFF
--- a/Sources/PcgRandom/OSUnfairLock.swift
+++ b/Sources/PcgRandom/OSUnfairLock.swift
@@ -1,7 +1,7 @@
-#if os(macOS) || os(iOS)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 import os
 
-@available(macOS 10.12, iOS 10.0, *)
+@available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
 struct OSUnfairLock : PcgRandomLocking {
 
     private var vault = os_unfair_lock()

--- a/Sources/PcgRandom/PcgRandom.swift
+++ b/Sources/PcgRandom/PcgRandom.swift
@@ -39,7 +39,7 @@ public class Pcg64Random : RandomNumberGenerator {
             return PThreadMutex()
         #else
 
-        if #available(macOS 10.12, iOS 10.0, *) {
+        if #available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *) {
             return OSUnfairLock()
         }
         else {

--- a/Sources/PcgRandomC/PcgRandom.c
+++ b/Sources/PcgRandomC/PcgRandom.c
@@ -1,1 +1,2 @@
-#include "include/PcgRandomC/PcgRandomC.h"
+#include "include/PcgRandomC/UInt128_32.h"
+#include "include/PcgRandomC/UInt128_64.h"

--- a/Sources/PcgRandomC/include/PcgRandomC/UInt128_32.h
+++ b/Sources/PcgRandomC/include/PcgRandomC/UInt128_32.h
@@ -1,0 +1,130 @@
+#pragma once
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifndef __LP64__
+
+typedef struct
+{
+    uint64_t lo;
+    uint64_t hi;
+} UInt128;
+
+
+UInt128
+uint128_add(UInt128 a, UInt128 b) {
+    uint64_t lo, hi, ci, co;
+    
+    lo = __builtin_addcll(a.lo, b.lo, 0, &ci);
+    hi = __builtin_addcll(a.hi, b.hi, ci, &co);
+    
+    UInt128 r = { lo, hi };
+    return r;
+}
+
+
+UInt128
+uint128_neg(UInt128 a) {
+    uint64_t lo, hi, ci, co;
+    
+    lo = __builtin_addcll(~a.lo, 1, 0, &ci);
+    hi = __builtin_addcll(~a.hi, 0, ci, &co);
+    
+    UInt128 r = { lo, hi };
+    return r;
+}
+
+
+UInt128
+uint128_add32(UInt128 a, uint32_t b) {
+    uint64_t lo, hi, ci, co;
+    
+    lo = __builtin_addcll(a.lo, b, 0, &ci);
+    hi = __builtin_addcll(a.hi, 0, ci, &co);
+    
+    UInt128 r = { lo, hi };
+    return r;
+}
+
+
+UInt128
+uint128_mul(UInt128 a, UInt128 b) {
+    uint64_t aw[4] = { (a.lo & 0xffffffff), (a.lo >> 32), (a.hi & 0xffffffff), (a.hi >> 32) },
+             bw[4] = { (b.lo & 0xffffffff), (b.lo >> 32), (b.hi & 0xffffffff), (b.hi >> 32) },
+             lo, hi, ci, co;
+    
+    lo = aw[0] * bw[0];
+    lo = __builtin_addcll(lo, aw[0] * bw[1], 0, &ci);
+    lo = __builtin_addcll(lo, aw[1] * bw[0], ci, &co);
+    
+    hi = aw[0] * bw[2];
+    hi = __builtin_addcll(hi, aw[0] * bw[3], co, &ci);
+    hi = __builtin_addcll(hi, aw[1] * bw[1], ci, &co);
+    hi = __builtin_addcll(hi, aw[1] * bw[2], co, &ci);
+    hi = __builtin_addcll(hi, aw[2] * bw[0], ci, &co);
+    hi = __builtin_addcll(hi, aw[2] * bw[1], co, &ci);
+    hi = __builtin_addcll(hi, aw[3] * bw[0], ci, &co);
+    
+    UInt128 r = { lo, hi };
+    return r;
+}
+
+
+uint32_t
+uint128_and32(UInt128 a, uint32_t b) {
+    uint32_t r = a.lo & b;
+    return r;
+}
+
+
+UInt128
+uint128_or32(UInt128 a, uint32_t b) {
+    UInt128 r = { a.lo | b, a.hi };
+    return r;
+}
+
+
+UInt128
+uint128_shl(UInt128 a, uint32_t b) {
+    uint64_t lo = 0, hi = 0, c = 0;
+    
+    if (b < 128) {
+        if (b < 64) {
+            lo = a.lo << b;
+            c = a.lo >> (64 - b);
+            hi = a.hi << b;
+        } else {
+            hi = a.lo << (b - 64);
+        }
+    }
+    
+    UInt128 r = { lo, hi | c };
+    return r;
+}
+
+
+UInt128
+uint128_shr(UInt128 a, uint32_t b) {
+    uint64_t lo = 0, hi = 0, c = 0;
+    if (b < 128) {
+        if (b < 64) {
+            lo = a.lo >> b;
+            c = a.hi << (64 - b);
+            hi = a.hi >> b;
+        } else {
+            lo = a.hi >> (b - 64);
+        }
+    }
+    UInt128 r = { lo | c, hi };
+    return r;
+}
+
+
+bool
+uint128_lt(UInt128 a, UInt128 b) {
+    return a.hi == b.hi
+        ? a.lo < b.lo
+        : a.hi < b.hi;
+}
+
+#endif

--- a/Sources/PcgRandomC/include/PcgRandomC/UInt128_32.h
+++ b/Sources/PcgRandomC/include/PcgRandomC/UInt128_32.h
@@ -4,8 +4,7 @@
 
 #ifndef __LP64__
 
-typedef struct
-{
+typedef struct {
     uint64_t lo;
     uint64_t hi;
 } UInt128;
@@ -106,6 +105,7 @@ uint128_shl(UInt128 a, uint32_t b) {
 UInt128
 uint128_shr(UInt128 a, uint32_t b) {
     uint64_t lo = 0, hi = 0, c = 0;
+    
     if (b < 128) {
         if (b < 64) {
             lo = a.lo >> b;
@@ -115,6 +115,7 @@ uint128_shr(UInt128 a, uint32_t b) {
             lo = a.hi >> (b - 64);
         }
     }
+    
     UInt128 r = { lo | c, hi };
     return r;
 }

--- a/Sources/PcgRandomC/include/PcgRandomC/UInt128_64.h
+++ b/Sources/PcgRandomC/include/PcgRandomC/UInt128_64.h
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef __LP64__
 
 typedef union {
     __uint128_t value;
@@ -80,3 +81,5 @@ bool
 uint128_lt(UInt128 a, UInt128 b) {
     return a.value < b.value;
 }
+
+#endif


### PR DESCRIPTION
Based on the availability of 64-bit longs
- we'll use the `__uint128_t` provided by the compiler (as before)
- or handle the words on our own (new)

The macro `__LP64__ ` seems to be a practical choice here, although something more `__uint128_t` related would be nice.

This enables building for *tvOS* and *watchOS*. :tada:
